### PR TITLE
Added body parser limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 var express = require('express');
 var app = express();
 
-app.use(express.bodyParser() );
+app.use(express.bodyParser({limit: '50mb'}));
 app.use(express.urlencoded() );
 app.use(express.json());
 app.use(express.static(__dirname + '/public'));


### PR DESCRIPTION
Since the images are sent through socket as base64, there is a chance that they might be really big strings and express.js fails if the post data is bigger than it's expected limit. By increasing the body parser limit to 50mb that issue is taken care of.
