### PR TITLE
Multiple image support with owl carousel.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,28 +1,84 @@
 <!DOCTYPE html>
 
 <html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <title></title>
-        <style>
-        body {
-          margin: 0px;
-          padding:0px;
-        }
-        </style>
-    </head>
+<head>
+	<meta charset="utf-8" />
+	<title></title>
+	<style>
+		body {
+			margin: 0px;
+			padding:0px;
+			font-size:7pt; 
+			font-family:Lucida Console; 
+			text-align:center;
+		}
 
-<body style="font-size:7pt; font-family:Lucida Console; text-align:center;background-color:#a0ffa0">
-casperView<br>
-  <script src="/socket.io/socket.io.js"></script>
-  <script>
-  var socket = io.connect(location.href)
-    .on('img', function (data) {
-      document.getElementById('img').attributes['src'].value = "data:image/jpeg;base64, " + data
-    });
-  </script>
+		.list-item-timestamp {
+		    font-size: 20px;
+		    font-weight: bold;
+		}
 
-  <img id="img" src="">
+		.list-item img{
+			display: block;
+			width: 100%;
+			height: auto;
+			-webkit-border-radius: 3px;
+			-moz-border-radius: 3px;
+			border-radius: 3px;
+		}
+	</style>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.theme.min.css">
+
+	<script src="/socket.io/socket.io.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.carousel.min.js"></script>
+
+	<script>
+		var socket = io.connect(location.href);
+		socket.on('img', addImage);
+		var $imagesContainer = null;
+
+		function buildImageEntry (data) {
+			var $elem = $('<div class="list-item"></div>'),
+				$img = $('<img/>', {src: "data:image/jpeg;base64, "+ data}),
+				time = new Date(),
+				$timestamp = $('<div class="list-item-timestamp">'+ time.toString() +'</div>');
+
+			$elem.append($timestamp).append($img);
+			// console.log($elem);
+			return $elem;
+		}
+
+		function addImage (data) {
+			if (!$imagesContainer)
+				return;
+
+			$imagesContainer.data('owlCarousel').addItem(buildImageEntry(data));
+		}
+
+		$(document).ready(function () {
+			$imagesContainer = $("#images");
+			$imagesContainer.owlCarousel({
+			    autoPlay : 3000,
+		        navigation:true,
+				paginationSpeed : 1000,
+			    stopOnHover : true,
+			    singleItem : true,
+    			autoHeight : true,
+				afterInit : function(elem){
+					this.owlControls.prependTo(elem)
+				}
+			});
+		});
+	</script>
+
+</head>
+
+<body>
+	<h1>casperView</h1>
+	
+	<div id="images" class="list"></div>
 </body>
 </html>
 

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,25 @@
 			-moz-border-radius: 3px;
 			border-radius: 3px;
 		}
+
+		.clear {
+			float: right;
+			margin-right: 20px;
+			display: inline-block;
+			background-color: #a51717;
+			padding: 15px 30px;
+			color: #ffffff;
+			border-radius: 5px;
+			border: 0 none;
+			font-size: 20px;
+			margin-top: 10px;
+			cursor: pointer;
+			z-index: 99999;
+		}
+
+		#images {
+			margin-top: 50px;
+		}
 	</style>
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.carousel.min.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.theme.min.css">
@@ -35,9 +54,22 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.carousel.min.js"></script>
 
 	<script>
-		var socket = io.connect(location.href);
+		var socket = io.connect(location.href),
+			$imagesContainer = null,
+			cleared = false,
+			owlOptions = {
+			    autoPlay : 3000,
+		        navigation:true,
+				paginationSpeed : 1000,
+			    stopOnHover : true,
+			    singleItem : true,
+    			autoHeight : true,
+				afterInit : function(elem){
+					this.owlControls.prependTo(elem)
+				}
+			};
+
 		socket.on('img', addImage);
-		var $imagesContainer = null;
 
 		function buildImageEntry (data) {
 			var $elem = $('<div class="list-item"></div>'),
@@ -54,21 +86,26 @@
 			if (!$imagesContainer)
 				return;
 
+			if (cleared) {
+				$imagesContainer.owlCarousel(owlOptions);
+				cleared = false;
+			}
+
 			$imagesContainer.data('owlCarousel').addItem(buildImageEntry(data));
 		}
 
 		$(document).ready(function () {
 			$imagesContainer = $("#images");
-			$imagesContainer.owlCarousel({
-			    autoPlay : 3000,
-		        navigation:true,
-				paginationSpeed : 1000,
-			    stopOnHover : true,
-			    singleItem : true,
-    			autoHeight : true,
-				afterInit : function(elem){
-					this.owlControls.prependTo(elem)
-				}
+			$imagesContainer.owlCarousel(owlOptions);
+
+
+			$('.clear').click(function (e) {
+				if (cleared)
+					return;
+
+				$imagesContainer.data('owlCarousel').destroy();
+				$imagesContainer.html('');
+				cleared = true;
 			});
 		});
 	</script>
@@ -76,8 +113,13 @@
 </head>
 
 <body>
-	<h1>casperView</h1>
-	
+	<div class="header">
+		<h1>
+			Casper View
+			<button class="clear">Clear Images</button>
+		</h1>
+	</div>
+
 	<div id="images" class="list"></div>
 </body>
 </html>


### PR DESCRIPTION
Hi,
This tool has been immensely helpful to me in every scraping project I've done. I have found it incredibly helpful to look at all the screens sequentially one after another but the tool seemed to only show one image at a time. So I made some modifications and added the owl carousel plugin to show images in a slider. You can also clear images when you're done debugging a sequence and the start a new sequence with new images. 

Please check it out and feel free to merge if it looks good. 

Regards
Foysal
